### PR TITLE
Make sure _CuraEngine is built as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ protobuf_generate_cpp(engine_PB_SRCS engine_PB_HEADERS Cura.proto)
 endif ()
 
 # Compiling CuraEngine itself.
-add_library(_CuraEngine ${engine_SRCS} ${engine_PB_SRCS}) #First compile all of CuraEngine as library, allowing this to be re-used for tests.
+add_library(_CuraEngine STATIC ${engine_SRCS} ${engine_PB_SRCS}) #First compile all of CuraEngine as library, allowing this to be re-used for tests.
 target_link_libraries(_CuraEngine clipper)
 if (ENABLE_ARCUS)
     target_link_libraries(_CuraEngine Arcus)


### PR DESCRIPTION
If the global BUILD_SHARED_LIBS is true, add_libray will default to
building shared libraries, which may be set due to distribution defaults.
As the intention obviously is to built and link statically (lib_CuraEngine
has no install target), force linking.